### PR TITLE
Added alternative implementation of i18n for hapi

### DIFF
--- a/lib/plugins.js
+++ b/lib/plugins.js
@@ -71,6 +71,10 @@ exports.categories = {
         hapil18n: {
             url: 'https://github.com/gpierret/hapi18n',
             description: 'i18n for Hapi'
+        },
+        'hapi-i18n': {
+            url: 'https://github.com/codeva/hapi-i18n',
+            description: 'Translation module for hapi based on mashpie\'s i18n module'
         }
     },
     'Logging/Metrics': {


### PR DESCRIPTION
This module uses mashpie's i18n module directly for localizations and ensures correct localization if multiple requests are processed at the same time.
